### PR TITLE
Fixup automatic access token refresh logic

### DIFF
--- a/chi/jupyterhub.py
+++ b/chi/jupyterhub.py
@@ -32,8 +32,9 @@ def refresh_access_token():
     """
     res = call_jupyterhub_api(ACCESS_TOKEN_ENDPOINT)
     access_token = res.get('access_token')
+    expires_at = res.get('expires_at')
 
     if not access_token:
         raise ValueError(f'Failed to get access token: {res}')
 
-    return access_token
+    return access_token, expires_at


### PR DESCRIPTION
Overriding only Session.request doesn't catch a few other use-cases,
notably looking up an endpoint from a Keystone service catalog. Since
this can happen _before_ request is called, it will fail. So, we have to
do something else: this commit updates the access_token on the auth
object to actually be a dynamically-bound `@property`, which can detect if
it needs to refresh synchronously.