### PR TITLE
Have images_list return images instead of object hash

### DIFF
--- a/chi/image.py
+++ b/chi/image.py
@@ -54,4 +54,4 @@ def list_images():
     Returns:
         All images associated with the current project.
     """
-    return glance().images.list()
+    return list(glance().images.list())


### PR DESCRIPTION
There is probably a better way to do this. Allows images_list to return more useful information.