### PR TITLE
Fixup handling of empty args, compat w/ v2

### DIFF
--- a/chi/container.py
+++ b/chi/container.py
@@ -45,18 +45,11 @@ __all__ = [
 def create_container(
     name: "str",
     image: "str" = None,
-    image_driver: "str" = DEFAULT_IMAGE_DRIVER,
-    device_profiles: "list[str]" = None,
-    environment: "dict" = None,
-    exposed_ports: "list[str]" = None, 
-    runtime: "str" = None,
-    nets: "list[dict]" = None,
-    network_id: "str" = None,
-    network_name: "str" = DEFAULT_NETWORK,
+    exposed_ports: "list[str]" = None,
     reservation_id: "str" = None,
     start: "bool" = True,
     start_timeout: "int" = None,
-    platform_version: "int" = None,
+    platform_version: "int" = 2,
     **kwargs,
 ) -> "Container":
     """Create a container instance.
@@ -65,10 +58,6 @@ def create_container(
         name (str): The name to give the container.
         image (str): The Docker image, with or without tag information. If no
             tag is provided, "latest" is assumed.
-        image_driver (str): The image storage driver to use to retrieve the
-            image. Defaults to "docker", meaning the image is assumed to be a
-            Docker registry repository. Specify "glance" to launch a snapshot
-            image by passing the Glance Image ID in the ``image`` argument.
         device_profiles (list[str]): An optional list of device profiles to
             request be configured on the container when it is created. Edge
             devices may have differing sets of supported device profiles, so
@@ -79,15 +68,6 @@ def create_container(
         exposed_ports (list[str]): A list of ports to expose on the container.
             TCP or UDP can be provided with a slash prefix, e.g., "80/tcp" vs.
             "53/udp". If no protocol is provided, TCP is assumed.
-        nets (list[dict]): A set of network configurations. This is an advanced
-            invocation; typically ``network_id`` or ``network_name`` should be
-            enough, and is much simpler. Refer to the `Zun documentation
-            <https://docs.openstack.org/api-ref/application-container/?expanded=create-new-container-detail#create-new-container>`_
-            for information about this parameter.
-        network_id (str): The ID of a network to launch the container on.
-        network_name (str): The name of a network to launch the container on.
-            This has no effect if ``network_id`` is already provided. Default
-            "containernet1".
         host (str): The Zun host to launch a container on. If not specified,
             the host is chosen by Zun.
         runtime (str): The container runtime to use. This should only be
@@ -99,12 +79,6 @@ def create_container(
         **kwargs: Additional keyword arguments to send to the Zun client's
             container create call.
     """
-
-    if not nets:
-        if not network_id:
-            network_id = get_network_id(network_name)
-        nets = [{"network": network_id}]
-
     hints = kwargs.setdefault("hints", {})
     if reservation_id:
         hints["reservation"] = reservation_id
@@ -114,28 +88,28 @@ def create_container(
     # Support simpler syntax for exposed_ports
     if exposed_ports and isinstance(exposed_ports, list):
         exposed_ports = {port_def: {} for port_def in exposed_ports}
+    # Only set exposed_ports on the parent invocation if it is non-empty. Otherwise,
+    # end-users cannot specify security groups; the client will send an explicit 'null'
+    # value for this key, which will fail validation in the API layer, which expects the
+    # key to be missing if security groups are specified.
+    if exposed_ports:
+        kwargs["exposed_ports"] = exposed_ports
 
-    # Note: ``host`` is not defined as an arg because there is some special
+    # Note: most documented args are not on the function signature because there is some special
     # handling of it in the Zun client; it is not sent if it is not on kwargs.
     # If it is on kwargs it is expected to be non-None.
     container = zun().containers.create(
         name=name,
         image=image,
-        image_driver=image_driver,
-        nets=nets,
-        device_profiles=device_profiles,
-        exposed_ports=exposed_ports,
-        environment=environment,
-        runtime=runtime,
         **kwargs,
     )
-    
+
     # Wait for a while, the image may need to download. 30 minutes is
     # _quite_ a long time, but the user can interrupt or choose a smaller
     # timeout.
     timeout = start_timeout or (60 * 30)
     LOG.info(f"Waiting up to {timeout}s for container creation ...")
-    
+
     if platform_version == 2:
         container = _wait_for_status(container.uuid, "Running", timeout=timeout)
     else:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -54,17 +54,12 @@ def example_create_container():
 def test_example_create_container(mocker):
     zun = mocker.patch("chi.container.zun")()
 
-    def get_network_id(network_name):
-        assert network_name == DEFAULT_NETWORK
-        return "network-id"
-
-    mocker.patch("chi.container.get_network_id", side_effect=get_network_id)
     mocker.patch("chi.lease.get_device_reservation", return_value="reservation-id")
     Container = namedtuple("Container", ["uuid", "name", "status"])
     mocker.patch(
         # Fake that the container is already created
         "chi.container.get_container",
-        return_value=Container("fake-uuid", "my-container", "Created"),
+        return_value=Container("fake-uuid", "my-container", "Running"),
     )
 
     example_create_container()
@@ -72,11 +67,5 @@ def test_example_create_container(mocker):
     zun.containers.create.assert_called_once_with(
         name="my_container",
         image="centos:8",
-        image_driver=DEFAULT_IMAGE_DRIVER,
-        hints={"reservation": "reservation-id"},
-        nets=[{"network": "network-id"}],
-        environment=None,
-        exposed_ports=None,
-        runtime=None,
-        device_profiles=None,
+        hints={"reservation": "reservation-id", "platform_version": 2},
     )


### PR DESCRIPTION
This defaults all requests to platform version 2, since we are now
rolled over to that.

It also fixes up some default arg handling. The Zun client will not
send an arg if it is not on kwargs, and the API will interpret that
as the arg is missing, which is OK for optional args. Importantly, some
args MUST be missing (exposed_ports when security_groups are defined,
for example.) This updates the handling to only document some helpful
args but not actually include them on the function signature, meaning
they will ride along w/ kwargs, if defined.