### PR TITLE
Handle mixed leases when searching for reservations with counts

### DIFF
--- a/chi/lease.py
+++ b/chi/lease.py
@@ -459,7 +459,7 @@ def get_node_reservation(
         if res.get("resource_type") != "physical:host":
             return False
         if count is not None and not all(
-            int(res.get(key)) == count for key in ["min_count", "max_count"]
+            int(res.get(key, -1)) == count for key in ["min_count", "max_count"]
         ):
             return False
         rp = res.get("resource_properties")


### PR DESCRIPTION
In `chi.lease.get_node_reservation`, if a `count` is provided, the lookup will fail because it searches all reservations for the values of `min_count` and `max_count`. Floating IP reservations have only an `amount`, so the comparison fails.

This change simply uses an invalid count for any reservations which have un-bounded counts.
