### PR TITLE
Allow passthrough arguments for SSH connections

### DIFF
--- a/chi/ssh.py
+++ b/chi/ssh.py
@@ -5,15 +5,17 @@ from . import context
 
 
 class Remote(Connection):
-    def __init__(self, ip=None, server=None, user="cc"):
+    def __init__(self, ip=None, server=None, user="cc", **kwargs):
         if ip is None:
             if server is None:
                 raise ValueError("ip or server must be provided.")
             ip = server.ip
 
+        if not kwargs.get("connect_kwargs"):
+            kwargs["connect_kwargs"] = {}
         key_filename = context.get("keypair_private_key")
-        connect_kwargs = {"key_filename": key_filename}
-        super(Remote, self).__init__(ip, user=user, connect_kwargs=connect_kwargs)
+        kwargs["connect_kwargs"].setdefault("key_filename", key_filename)
+        super(Remote, self).__init__(ip, user=user, **kwargs)
         # Default policy is to reject unknown hosts - for our use-case,
         # printing a warning is probably enough, given the host is almost
         # always guaranteed to be unknown.


### PR DESCRIPTION
This allows users to make more use of complex SSH configuration. The existing interface only allowed for direct connection to a single host. This made basic things like jump hosts inaccessible.

Users can now pass through any keyword arguments accepted by [`fabric.Connection`](https://docs.fabfile.org/en/stable/api/connection.html)
