### PR TITLE
bump minimum API version for zun

### DIFF
--- a/chi/clients.py
+++ b/chi/clients.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 session_factory = session
 
 NOVA_API_VERSION = "2.10"
-ZUN_API_VERSION = "1"
+ZUN_API_VERSION = "1.41"
 
 
 def connection(session=None) -> "Connection":


### PR DESCRIPTION
ensure zun client uses an API microversion that supports device profiles.

In our xena branch of zun, device_profiles require version 1.41, whereas in our older branch, it required 1.40. https://github.com/ChameleonCloud/zun/blob/7f87893db9eed930fd8fb38eb9d66da974eb7991/zun/api/controllers/v1/schemas/containers.py#L81-L82 https://github.com/ChameleonCloud/zun/blob/3b01255e7aeb93369be1d0ede579f3f06e238917/zun/api/controllers/v1/schemas/containers.py#L77-L78

This is because we add to the "end" of the API microversions, and upstream added a new one in between train and xena.