### PR TITLE
manila share uses list with argument search_opt

### DIFF
--- a/chi/share.py
+++ b/chi/share.py
@@ -111,7 +111,7 @@ def get_share_id(name):
         ValueError: If the share could not be found, or if multiple shares
             matched the name.
     """
-    shares = list(manila().shares.list(filters={'name': name}))
+    shares = list(manila().shares.list(search_opts={'name': name}))
     if not shares:
         raise ValueError(f'No shares found matching name "{name}"')
     elif len(shares) > 1:


### PR DESCRIPTION
This fixes the error when  `chi.share.get_share_id` is called

/opt/conda/lib/python3.10/site-packages/manilaclient/api_versions.py in substitution(obj, *args, **kwargs)
    397             method = max(methods, key=lambda f: f.start_version)
    398 
--> 399             return method.func(obj, *args, **kwargs)
    400 
    401         if hasattr(func, 'arguments'):

TypeError: ShareManager.list() got an unexpected keyword argument 'filters'