### PR TITLE
Added download and associate_floating_ip methods to __all__ in container.py

### DIFF
--- a/chi/container.py
+++ b/chi/container.py
@@ -38,7 +38,9 @@ __all__ = [
     "get_logs",
     "execute",
     "upload",
+    "download",
     "wait_for_active",
+    "associate_floating_ip",
 ]
 
 


### PR DESCRIPTION
container.download() and container.associate_floating_ip are both methods that should be included in the __all__ list to ensure the generation of their docs by sphinx.