### PR TITLE
Updates for python-chi 1.1

### DIFF
--- a/chi/container.py
+++ b/chi/container.py
@@ -292,6 +292,21 @@ class Container:
         """
         return associate_floating_ip(self.id, fip)
 
+    def logs(self, stdout: str = True, stderr: str = True) -> str:
+        """
+        Print all logs outputted by the container.
+
+        Args:
+            container_ref (str): The name or ID of the container.
+            stdout (bool): Whether to include stdout logs. Default True.
+            stderr (bool): Whether to include stderr logs. Default True.
+
+        Returns:
+            A string containing all log output. Log lines will be delimited by
+                newline characters.
+        """
+        return get_logs(self.id, stdout=stdout, stderr=stderr)
+
 
 def create_container(
     name: "str",
@@ -515,7 +530,7 @@ def download(container_ref: "str", source: "str", dest: "str"):
     res = zun().containers.get_archive(container_ref, source)
     fd = io.BytesIO(res["data"])
     with tarfile.open(fileobj=fd, mode="r") as tar:
-        tar.extraction_filter = (lambda member, path: member)
+        tar.extraction_filter = lambda member, path: member
         tar.extractall(dest)
 
 

--- a/chi/context.py
+++ b/chi/context.py
@@ -26,6 +26,9 @@ DEFAULT_AUTH_TYPE = "v3token"
 DEFAULT_NETWORK = "sharednet1"
 CONF_GROUP = "chi"
 RESOURCE_API_URL = os.getenv("CHI_RESOURCE_API_URL", "https://api.chameleoncloud.org")
+EDGE_RESOURCE_API_URL = os.getenv(
+    "EDGE_RESOURCE_API_URL", "https://chameleoncloud.org/edge-hw-discovery/devices"
+)
 
 
 def default_key_name():

--- a/chi/hardware.py
+++ b/chi/hardware.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Set, Tuple
 from chi import exception
 
 from .clients import blazar, connection
-from .context import get, RESOURCE_API_URL, session
+from .context import get, RESOURCE_API_URL, EDGE_RESOURCE_API_URL, session
 
 
 import requests
@@ -180,7 +180,9 @@ def get_nodes(
                             reserved_now.add(blazar_host["hypervisor_hostname"])
 
         for node_data in data["items"]:
-            blazar_host = blazar_hosts_by_hypervisor_hostname.get(node_data.get("uid"), {})
+            blazar_host = blazar_hosts_by_hypervisor_hostname.get(
+                node_data.get("uid"), {}
+            )
             node = Node(
                 site=site,
                 name=node_data.get("node_name"),
@@ -326,8 +328,7 @@ def get_devices(
         List[Device]: A list of Device objects that match the specified criteria.
     """
     # Query hardware API
-    url = "https://dev.chameleoncloud.org/edge-hw-discovery/devices"
-    res = requests.get(url)
+    res = requests.get(EDGE_RESOURCE_API_URL)
     try:
         res.raise_for_status()
     except requests.exceptions.HTTPError:

--- a/chi/hardware.py
+++ b/chi/hardware.py
@@ -346,7 +346,7 @@ def get_devices(
 
     devices = []
     for dev_json in res.json():
-        blazar_host = blazar_devices_by_uid.get(dev_json.get("uid"), {})
+        blazar_host = blazar_devices_by_uid.get(dev_json.get("uuid"), {})
         devices.append(
             Device(
                 device_name=dev_json["device_name"],
@@ -393,7 +393,8 @@ def get_devices(
                     if _reserved_now(allocation, now):
                         reserved_devices.add(blazar_device["uid"])
         for device in matching_type_devices:
-            if device.uuid not in reserved_devices:
+            # Ensure the device is free and in `reservable` state
+            if device.uuid not in reserved_devices and device.reservable:
                 unreserved_devices.append(device)
 
     return unreserved_devices

--- a/chi/lease.py
+++ b/chi/lease.py
@@ -423,7 +423,7 @@ class Lease:
             None
         """
 
-        print("Waiting for lease to start... This can take up to 60 seconds")
+        print("Waiting for lease to start...")
 
         pb = util.TimerProgressBar()
         if show == "widget" and _is_ipynb():

--- a/chi/server.py
+++ b/chi/server.py
@@ -158,6 +158,7 @@ class Server:
         show: str = "widget",
         idempotent: bool = False,
         retry_on_error: bool = False,
+        wait_timeout: int = 20 * 60,
         **kwargs,
     ) -> "Server":
         """
@@ -168,6 +169,7 @@ class Server:
             show (str, optional): The type of server information to display after creation. Defaults to "widget".
             idempotent (bool, optional): Whether to create the server only if it doesn't already exist. Defaults to False.
             retry_on_error (bool, optional): Whether to retry the server creation if creation fails. Defaults to False.
+            wait_timeout (int): How long to wait for server to start in seconds. Default 20 minutes.
 
         Raises:
             Conflict: If the server creation fails due to a conflict and idempotent mode is not enabled.
@@ -198,7 +200,7 @@ class Server:
         def _server_create_func():
             self.conn.compute.create_server(**server_args)
             if wait_for_active:
-                self.wait()
+                self.wait(timeout=wait_timeout)
             if show:
                 self.show(type=show)
 

--- a/chi/util.py
+++ b/chi/util.py
@@ -61,17 +61,18 @@ class TimerProgressBar:
     def display(self):
         display(widgets.HBox([self.label, self.progress]))
 
-    def wait(self, callback, expected_timeout, timeout):
+    def wait(self, callback, expected_timeout, timeout, interval=5):
         """Wait and update the progress bar.
 
         Args:
             callback (function): bool function for whether to break
             expected_timeout (int): how long the progress bar should expect to wait for in seconds. Will display 90% when reached
             timeout (int): The time to reach 100% of the progress bar
-
+            interval (int): The time to wait between checking the callback)
         Returns:
             Whether callback returned true before timeout
         """
+        expected_proportion = 0.9
         start_time = time.time()
         while time.time() - start_time < timeout:
             if callback():
@@ -81,12 +82,18 @@ class TimerProgressBar:
             self.label.value = f"{str(elapased).split('.')[0]} elapsed."
 
             if elapased.total_seconds() < expected_timeout:
-                self.progress.value = 100 * elapased.total_seconds() / expected_timeout
-            else:
                 self.progress.value = (
-                    10
+                    100
+                    * expected_proportion
+                    * elapased.total_seconds()
+                    / expected_timeout
+                )
+            else:
+                self.progress.value = 100 * (
+                    expected_proportion
+                    + (1 - expected_proportion)
                     * (elapased.total_seconds() - expected_timeout)
                     / (timeout - expected_timeout)
                 )
-            time.sleep(5)
+            time.sleep(interval)
         return False

--- a/chi/util.py
+++ b/chi/util.py
@@ -4,6 +4,7 @@ import time
 from dateutil import tz
 from hashlib import md5
 import os
+from chi.exception import ResourceError
 import ipywidgets as widgets
 from IPython.display import display
 
@@ -97,3 +98,17 @@ class TimerProgressBar:
                 )
             time.sleep(interval)
         return False
+
+
+def retry_create(max_attempts, create_func, cleanup_func):
+    attempt = 0
+    while attempt < 3:
+        try:
+            create_func()
+            break
+        except Exception as e:
+            attempt += 1
+            if attempt == max_attempts:
+                raise ResourceError(e)
+            print(f"Error creating resource on attempt {attempt}/{max_attempts}.")
+            cleanup_func()


### PR DESCRIPTION
* Add a timeout parameter to Lease, Server, Container wait methods. This may be needed for some node types, or if a lease is starting in the future.
* Add automatic IP cleanup to `Server.delete()`
* Add CHI@Edge support in the `hardware` module. This adds the `Device` class and `get_devices` class, similar to `get_nodes`.
* Add `retry_on_error` parameter to Lease and Server submit. If set to `True`, submission will be attempted 3 times in the event than an error appears.
* Add missing `Container.logs` and `Container.detach_floating_ip` methods.
* Improve `Container` interface. Add missing progress bar to `Container.submit()`, and command and workdir parameters.

NOTE: Requires https://github.com/ChameleonCloud/portal-camino/pull/15 to expose the edge HW api.