### PR TITLE
add unittests for container file upload/download

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -11,10 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import io
+import os
+import tarfile
+import tempfile
 from datetime import datetime
 
 import pytest
 
+from chi.container import Container, download, upload
 
 
 @pytest.fixture()
@@ -22,49 +27,86 @@ def now():
     return datetime(2021, 1, 1, 0, 0, 0, 0)
 
 
-def example_create_container():
-    """Launch a container.
-
-    <div class="alert alert-info">
-
-    **Functions used in this example:**
-
-    * [create_container](../modules/container.html#chi.container.create_container)
-    * [get_device_reservation](../modules/lease.html#chi.lease.get_device_reservation)
-
-    </div>
-
-    """
-    from chi.container import create_container
-    from chi.lease import get_device_reservation
-
-    # We assume a lease has already been created, for example with
-    # ``chi.lease.create_lease```
-    lease_name = "my_lease"
-    container_name = "my_container"
-    reservation_id = get_device_reservation(lease_name)
-    create_container(
-        container_name,
-        image="centos:8",
-        reservation_id=reservation_id,
+def test_container_upload_method(mocker):
+    # Arrange
+    mock_upload = mocker.patch("chi.container.upload")
+    container = Container(
+        name="test",
+        image_ref="image",
+        exposed_ports=[],
     )
+    container.id = "fake_id"
+    source = "/tmp/sourcefile"
+    remote_dest = "/container/path"
+
+    # Act
+    container.upload(source, remote_dest)
+
+    # Assert
+    mock_upload.assert_called_once_with("fake_id", source, remote_dest)
 
 
-# def test_example_create_container(mocker):
-#     zun = mocker.patch("chi.container.zun")()
+def test_container_download_method(mocker):
+    # Arrange
+    mock_download = mocker.patch("chi.container.download")
+    container = Container(
+        name="test",
+        image_ref="image",
+        exposed_ports=[],
+    )
+    container.id = "fake_id"
+    remote_source = "/container/path"
+    dest = "/tmp/destfile"
 
-#     mocker.patch("chi.lease.get_device_reservation", return_value="reservation-id")
-#     Container = namedtuple("Container", ["uuid", "name", "status"])
-#     mocker.patch(
-#         # Fake that the container is already created
-#         "chi.container.get_container",
-#         return_value=Container("fake-uuid", "my-container", "Running"),
-#     )
+    # Act
+    container.download(remote_source, dest)
 
-#     example_create_container()
+    # Assert
+    mock_download.assert_called_once_with("fake_id", remote_source, dest)
 
-#     zun.containers.create.assert_called_once_with(
-#         name="my_container",
-#         image="centos:8",
-#         hints={"reservation": "reservation-id", "platform_version": 2},
-#     )
+
+def test_upload_creates_tar_and_calls_put_archive(mocker):
+    # Patch zun client
+    zun_mock = mocker.patch("chi.container.zun")()
+    # Create a temporary file to upload
+    with tempfile.NamedTemporaryFile() as tmpfile:
+        tmpfile.write(b"hello world")
+        tmpfile.flush()
+
+        upload("container_id", tmpfile.name, "/remote/path")
+        # Check that put_archive was called
+        assert zun_mock.containers.put_archive.call_count == 1
+        args = zun_mock.containers.put_archive.call_args[0]
+        assert args[0] == "container_id"
+        assert args[1] == "/remote/path"
+        # The third argument should be a tar archive containing the file
+        tar_bytes = args[2]
+        tarfileobj = io.BytesIO(tar_bytes)
+        with tarfile.open(fileobj=tarfileobj, mode="r") as tar:
+            names = tar.getnames()
+            assert os.path.basename(tmpfile.name) in names
+
+
+def test_download_extracts_tar_and_writes_file(mocker):
+    # Patch zun client
+    zun_mock = mocker.patch("chi.container.zun")()
+    # Create a tar archive in memory with a test file
+    file_content = b"test content"
+    file_name = "testfile.txt"
+    tar_bytes_io = io.BytesIO()
+    with tarfile.open(fileobj=tar_bytes_io, mode="w") as tar:
+        info = tarfile.TarInfo(name=file_name)
+        info.size = len(file_content)
+        tar.addfile(info, io.BytesIO(file_content))
+    tar_bytes = tar_bytes_io.getvalue()
+    zun_mock.containers.get_archive.return_value = {"data": tar_bytes}
+
+    # Use a temporary directory for extraction
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dest_path = os.path.join(tmpdir, file_name)
+
+        download("container_id", file_name, tmpdir)
+        # Check that the file was extracted
+        assert os.path.exists(dest_path)
+        with open(dest_path, "rb") as f:
+            assert f.read() == file_content


### PR DESCRIPTION
in chi@edge, e.g. zun-api backed by kubernetes, file upload/download is fairly brittle. The API implementaton assumes that the payload is a tar file, in base64 encoding. The tar file may include multiple files, but the destination of the upload/download is always a directory, even in the case that a single file is sent.

As this is unintuitive, and frequent errors happen due to file encoding, these tests try to illustrate the "known working" behavior.