### PR TITLE
Fix condition with usage_type and stitch provider

### DIFF
--- a/chi/lease.py
+++ b/chi/lease.py
@@ -1069,13 +1069,13 @@ def add_network_reservation(
 
     if physical_network:
         extra_constraints.append(["==", "$physical_network", physical_network])
-    if stitch_provider and stitch_provider != "fabric":
+    if stitch_provider == "fabric":
         extra_constraints.append(["==", "$stitch_provider", stitch_provider])
-    else:
+    elif stitch_provider is not None:
         raise CHIValueError("stitch_provider must be 'fabric' or None")
-    if usage_type and usage_type != "storage":
+    if usage_type == "storage":
         extra_constraints.append(["==", "$usage_type", usage_type])
-    else:
+    elif usage_type is not None:
         raise CHIValueError("usage_type must be 'storage' or None")
 
     resource_properties = _format_resource_properties(

--- a/chi/server.py
+++ b/chi/server.py
@@ -191,7 +191,7 @@ class Server:
             image=self.image_name,
             flavor=self.flavor_name,
             key=self.keypair.name,
-            net_ids=[chi_network.get_network_id(DEFAULT_NETWORK)],
+            net_ids=[chi_network.get_network_id(self.network_name)],
             **kwargs,
         )
 


### PR DESCRIPTION
I encountered some error messages while working with networks. These seem like quick fixes at first glance, but please let me know if I'm on the right track.

1) The error message seemed contradictory, as stitch_provider="fabric" and usage_type="storage" should work when creating     the lease. However, when I tried to create a network reservation using Python CHI, I kept encountering errors.
Don't think it is getting picked up in any tests.

2) I was trying to create a server using `submit`, looks like it is defaulting to sharednet1 but should be the network name.